### PR TITLE
chore(be): context current parameters

### DIFF
--- a/backend/constitution-checker-backend.cabal
+++ b/backend/constitution-checker-backend.cabal
@@ -50,6 +50,7 @@ library
         , Cardano.Constitution.Checker.Params.Swagger
         , Cardano.Constitution.Checker.Params.Lookup
         , Cardano.Constitution.Checker.Types
+        , Cardano.Constitution.Checker.Context
         , Cardano.Constitution.Checker.Checks
         , Cardano.Constitution.Checker.Blockfrost
         , Cardano.Constitution.Checker.Blockfrost.Override

--- a/backend/src/Cardano/Constitution/Checker/API.hs
+++ b/backend/src/Cardano/Constitution/Checker/API.hs
@@ -10,6 +10,7 @@ import Servant.Swagger.UI
 
 import Cardano.Constitution.Checker.Checks hiding (description)
 
+import Cardano.Constitution.Checker.Context
 import Cardano.Constitution.Checker.Params.Types
 import Cardano.Constitution.Checker.Types
 import Control.Lens hiding (Context (..), (.=))

--- a/backend/src/Cardano/Constitution/Checker/Context.hs
+++ b/backend/src/Cardano/Constitution/Checker/Context.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Cardano.Constitution.Checker.Context (
+  mkContext,
+) where
+
+import Cardano.Constitution.Checker.Blockfrost (ProtocolParams (..))
+import Cardano.Constitution.Checker.Params.Lookup
+import Cardano.Constitution.Checker.Params.Types
+import Cardano.Constitution.Checker.Types
+import Control.Applicative ((<|>))
+import Data.Map
+import qualified GHC.IsList as Haskell
+
+-- import qualified Data.Swagger as SWG
+
+mkContext :: ParametersChange -> ProtocolParams -> Context
+mkContext (MkParametersChange m') currentValues' =
+  Context
+    { proposal = proposal'
+    , merged = merged'
+    , currentValues = currentParams'
+    }
+ where
+  proposal' = paramsAccess m'
+  currentParams' = paramsAccess currentParams
+  merged' =
+    ParamsAccess
+      { byName = mergedByParameter byName
+      , byIx = mergedByParameter byIx
+      }
+  mergedByParameter :: (ParamsAccess -> ByParameter a) -> ByParameter a
+  mergedByParameter f =
+    ByParameter
+      { getInteger = searchInBoth f getInteger
+      , getRational = searchInBoth f getRational
+      , getIntegers = searchInBoth' f getIntegers
+      , getRationals = searchInBoth' f getRationals
+      , getCostModels = \ix' ->
+          let (pV1, pV2, pV3) = getCostModels (f proposal') ix'
+              (cV1, cV2, vV3) = getCostModels (f currentParams') ix'
+           in (pV1 <|> cV1, pV2 <|> cV2, pV3 <|> vV3)
+      }
+
+  searchInBoth ::
+    (ParamsAccess -> ByParameter a) ->
+    (ByParameter a -> (a -> Maybe b)) ->
+    a ->
+    Maybe b
+  searchInBoth f extractor ix' =
+    let a = extractor (f proposal') ix'
+        b = extractor (f currentParams') ix'
+     in a <|> b
+
+  searchInBoth' ::
+    (ParamsAccess -> ByParameter a) ->
+    (ByParameter a -> (a -> Map String b)) ->
+    a ->
+    Map String b
+  searchInBoth' f extractor ix' =
+    let a = extractor (f proposal') ix'
+        b = extractor (f currentParams') ix'
+     in a <> b
+
+  EpochParameters _ (MkParametersChange currentParams) =
+    allCurrentParamsValues currentValues'
+
+paramsAccess :: Map Integer ParamValue -> ParamsAccess
+paramsAccess m = ParamsAccess (byName' xs) (byIx' m)
+ where
+  xs = snd <$> toList m
+
+-- ~~ utils ~~
+byName' :: [ParamValue] -> ByParameter String
+byName' xs = byParameter' (withParamName xs)
+
+byIx' :: Map Integer ParamValue -> ByParameter Integer
+byIx' m = byParameter' (withParamIx m)
+
+withParamName :: [ParamValue] -> (forall a. Maybe (Param a, a) -> b) -> String -> b
+withParamName xs f name' =
+  let
+    nameMap = Haskell.fromList $ zip (allNames xs) xs
+    allNames = fmap (\(MkParamValue p _) -> paramName p)
+   in
+    case Data.Map.lookup name' nameMap of
+      Just (MkParamValue p v) -> f $ Just (p, v)
+      Nothing -> f Nothing
+
+withParamIx :: Map Integer ParamValue -> (forall a. Maybe (Param a, a) -> b) -> Integer -> b
+withParamIx m f ix' = case Data.Map.lookup ix' m of
+  Just (MkParamValue p v) -> f $ Just (p, v)
+  Nothing -> f Nothing
+
+byParameter' ::
+  (forall b. (forall a. Maybe (Param a, a) -> b) -> s -> b) ->
+  ByParameter s
+byParameter' f =
+  ByParameter
+    { getInteger = f \case
+        Just (Scalar{}, val) | [v] <- lookupInteger' val -> Just v
+        _otherwise -> Nothing
+    , getRational = f \case
+        Just (Scalar{}, val) | [v] <- lookupRational' val -> Just v
+        _otherwise -> Nothing
+    , getIntegers = f \case
+        Just (param@Collection{}, val) -> lookupInteger param val
+        _otherwise -> empty
+    , getRationals = f \case
+        Just (param@Collection{}, val) -> lookupRational param val
+        _otherwise -> empty
+    , getCostModels = f \case
+        Just (param, val) -> lookupCostModels param val
+        _otherwise -> (Nothing, Nothing, Nothing)
+    }

--- a/backend/src/Cardano/Constitution/Checker/Params/Definition.hs
+++ b/backend/src/Cardano/Constitution/Checker/Params/Definition.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
@@ -467,8 +468,8 @@ govActionLifetime =
     [ ("GAL-01", "govActionLifetime must not be lower than 1 epoch (5 days)") `MustNotBe` NL 1
     , ("GAL-02", "govActionLifetime must not be greater than 15 epochs (75 days)") `MustNotBe` NG 15
     , ("GAL-05", "govActionLifetime must be less than dRepActivity")
-        `ShouldSatisfy` \(byName -> findInteger "dRepActivity" -> dRepActivityM) val ->
-          case dRepActivityM of
+        `ShouldSatisfy` \ctx val ->
+          case ctx.merged.byName.getInteger "dRepActivity" of
             Just dRepActivity'
               | val < dRepActivity' -> Satisfied
               | otherwise -> Unsatisfied "govActionLifetime must be less than dRepActivity"

--- a/backend/src/Cardano/Constitution/Checker/Params/Lookup.hs
+++ b/backend/src/Cardano/Constitution/Checker/Params/Lookup.hs
@@ -30,6 +30,10 @@ instance Lookup [Integer] where
   lookupRational' _ = []
   lookupInteger' val = val
 
+instance Lookup (Maybe PV1, Maybe PV2, Maybe PV3) where
+  lookupRational' _ = []
+  lookupInteger' _ = []
+
 lookup' :: (a -> [b]) -> Param a -> a -> Map String b
 lookup' f (Scalar _ name _) val = Map.fromList $ zip [name] $ f val
 lookup' f (Collection _ _ params) val =
@@ -42,3 +46,8 @@ lookupRational = lookup' lookupRational'
 
 lookupInteger :: forall a. (Lookup a) => Param a -> a -> Map String Integer
 lookupInteger = lookup' lookupInteger'
+
+lookupCostModels :: Param a -> a -> (Maybe PV1, Maybe PV2, Maybe PV3)
+lookupCostModels (Scalar{}) _ = (Nothing, Nothing, Nothing)
+lookupCostModels (Collection{}) _ = (Nothing, Nothing, Nothing)
+lookupCostModels (CostModels{}) val = val

--- a/backend/src/Cardano/Constitution/Checker/Params/Types.hs
+++ b/backend/src/Cardano/Constitution/Checker/Params/Types.hs
@@ -77,6 +77,7 @@ data ByParameter a = ByParameter
   , getRational :: !(a -> Maybe Rational)
   , getIntegers :: !(a -> Map String Integer)
   , getRationals :: !(a -> Map String Rational)
+  , getCostModels :: !(a -> (Maybe PV1, Maybe PV2, Maybe PV3))
   }
 
 findInteger :: a -> ByParameter a -> Maybe Integer
@@ -91,10 +92,15 @@ findIntegers = getIntegers
 findRationals :: ByParameter a -> a -> Map String Rational
 findRationals = getRationals
 
-data Context = Context
+data ParamsAccess = ParamsAccess
   { byName :: !(ByParameter String)
   , byIx :: !(ByParameter Integer)
-  , currentParams :: !ProtocolParams
+  }
+
+data Context = Context
+  { proposal :: !ParamsAccess
+  , merged :: !ParamsAccess
+  , currentValues :: !ParamsAccess
   }
 
 data SatisfactionResult

--- a/backend/src/Cardano/Constitution/Checker/Types.hs
+++ b/backend/src/Cardano/Constitution/Checker/Types.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
@@ -9,11 +10,10 @@
 
 module Cardano.Constitution.Checker.Types (
   EpochParameters (..),
-  ParametersChange,
+  ParametersChange (..),
   mkParametersChangeUnsafe,
   ParamValue (..),
   unParametersChange,
-  mkContext,
   allCurrentParamsValues,
 ) where
 
@@ -26,12 +26,13 @@ import qualified Data.Aeson.KeyMap as KM
 import Blockfrost.Client (Epoch)
 import Cardano.Constitution.Checker.Blockfrost (ProtocolParams (..))
 import Cardano.Constitution.Checker.Params.Lookup
+import Control.Applicative ((<|>))
 import Control.Lens hiding (Context, (.=))
 import Control.Monad (foldM)
 import Data.Aeson
 import Data.Aeson.Types (Parser)
 import Data.Data (Proxy (..))
-import Data.Map hiding (fromList)
+import Data.Map
 import Data.String
 import Data.Swagger hiding (Param)
 import qualified GHC.IsList as Haskell
@@ -40,47 +41,6 @@ import qualified GHC.IsList as Haskell
 
 newtype ParametersChange = MkParametersChange (Map Integer ParamValue)
   deriving (Show, Eq)
-
-mkContext :: ParametersChange -> ProtocolParams -> Context
-mkContext (MkParametersChange m) = Context byName' byIx'
- where
-  xs = snd <$> toList m
-  byName' = byParameter' withParamName
-  byIx' = byParameter' withParamIx
-
-  nameMap :: Map String ParamValue
-  nameMap = Haskell.fromList $ zip allNames xs
-
-  allNames = fmap (\(MkParamValue p _) -> paramName p) xs
-
-  withParamIx :: (forall a. Maybe (Param a, a) -> b) -> Integer -> b
-  withParamIx f ix' = case Data.Map.lookup ix' m of
-    Just (MkParamValue p v) -> f $ Just (p, v)
-    Nothing -> f Nothing
-
-  withParamName :: (forall a. Maybe (Param a, a) -> b) -> String -> b
-  withParamName f name' = case Data.Map.lookup name' nameMap of
-    Just (MkParamValue p v) -> f $ Just (p, v)
-    Nothing -> f Nothing
-
-byParameter' ::
-  (forall b. (forall a. Maybe (Param a, a) -> b) -> s -> b) ->
-  ByParameter s
-byParameter' f =
-  ByParameter
-    { getInteger = f \case
-        Just (Scalar{}, val) | [v] <- lookupInteger' val -> Just v
-        _otherwise -> Nothing
-    , getRational = f \case
-        Just (Scalar{}, val) | [v] <- lookupRational' val -> Just v
-        _otherwise -> Nothing
-    , getIntegers = f \case
-        Just (param@Collection{}, val) -> lookupInteger param val
-        _otherwise -> empty
-    , getRationals = f \case
-        Just (param@Collection{}, val) -> lookupRational param val
-        _otherwise -> empty
-    }
 
 unParametersChange :: ParametersChange -> Map Integer ParamValue
 unParametersChange (MkParametersChange m) = m
@@ -97,18 +57,18 @@ data ParamValue = forall a. (ToJSON a) => MkParamValue !(Param a) !a
 --------------------------------------------------------------------------------
 -- TODO: move these from Types (maybe into API)
 paramValueFromCurrent :: ProtocolParams -> ParamWithCurrentValue -> ParamValue
-paramValueFromCurrent currentValues (ParamWithCurrentValue param@(Scalar{}) f) =
-  MkParamValue param (f currentValues)
-paramValueFromCurrent currentValues (ParamWithCurrentValue param@(Collection{}) f) =
-  MkParamValue param (f currentValues)
-paramValueFromCurrent currentValues (ParamWithCurrentValue param@(CostModels{}) f) =
-  MkParamValue param (f currentValues)
+paramValueFromCurrent currentValues' (ParamWithCurrentValue param@(Scalar{}) f) =
+  MkParamValue param (f currentValues')
+paramValueFromCurrent currentValues' (ParamWithCurrentValue param@(Collection{}) f) =
+  MkParamValue param (f currentValues')
+paramValueFromCurrent currentValues' (ParamWithCurrentValue param@(CostModels{}) f) =
+  MkParamValue param (f currentValues')
 
 allCurrentParamsValues :: ProtocolParams -> EpochParameters
-allCurrentParamsValues currentValues =
-  EpochParameters (_protocolParamsEpoch currentValues) $
+allCurrentParamsValues currentValues' =
+  EpochParameters (_protocolParamsEpoch currentValues') $
     mkParametersChangeUnsafe $
-      fmap (paramValueFromCurrent currentValues) allParamsWithCurrentValues
+      fmap (paramValueFromCurrent currentValues') allParamsWithCurrentValues
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
the custom guardrails now have access at the proposal but also at the current parameters 
1. access to proposal and to current parameters
```haskell
data Context = Context
  { proposal :: !ParamsAccess
  , merged :: !ParamsAccess
  , currentValues :: !ParamsAccess
  }
```
 - current proposal (in which all the user-provided values can be found)
 - current values (param values found on the last epoch)
 - merged ( first it's searched into the proposal and if there is no value, the current-value of the parameter is provided)
2. In `ParamsAccess` the cost models  was added 
