### PR TITLE
add an additional guardrail status indicatory for notMandatory

### DIFF
--- a/frontend/src/components/BodyTableRow.tsx
+++ b/frontend/src/components/BodyTableRow.tsx
@@ -17,7 +17,7 @@ const statusToColor = (status: string): "disabled" | "inherit" | "primary" | "se
   switch (status) {
       case "active": return "success"; // passing check
       case "inactive": return "error"; // failing check
-      case "pending": return "warning"; // not checked
+      case "notMandatory": return "secondary"; // not checked
       default: return "disabled";
   }
 }

--- a/frontend/src/components/GuardrailView.tsx
+++ b/frontend/src/components/GuardrailView.tsx
@@ -380,12 +380,13 @@ export default function GuardrailView() {
   }
 
   const getStatus = (field: string[], guardrail: string) => { 
-    let guardrailDetails = (currentJsonState as any || {})[field[0]];  
+    let guardrailDetails = (currentJsonState as any || {})[field[0]]; 
+    
     if (field.length > 1) {
       guardrailDetails = guardrailDetails[field[1]];
     }
-    if (guardrailDetails && guardrailDetails.checkStatus === 'unchecked') {
-      return 'pending';
+    if (guardrailDetails && (guardrailDetails.checkStatus === 'unchecked')) {
+      return 'disabled';
     }
 
     let result = (validationResults as any || {})[field[0]];  
@@ -393,9 +394,13 @@ export default function GuardrailView() {
       result = result[field[1]];
     }
     if (result && result.guardrails && result.guardrails[guardrail] && result.guardrails[guardrail].result !== null) {
-      return result.guardrails[guardrail].result ? 'active' : 'inactive';
+      
+      if (!result.guardrails[guardrail].isMandatory) {
+        return result.guardrails[guardrail].result ? 'notMandatory' : 'inactive';
+      } else {
+        return result.guardrails[guardrail].result ? 'active' : 'inactive';
+      }
     } 
-
     return 'disabled';
   };
 

--- a/frontend/src/components/MoreDetailsDrawer.tsx
+++ b/frontend/src/components/MoreDetailsDrawer.tsx
@@ -74,9 +74,11 @@ export default function MoreDetailsDrawer() {
     return (
       <div>
         {Object.entries(guardrails).map(([key, value]) => {
-          let variant: 'successText' | 'errorText' | 'body3';
-          if (value.result === true) {
+          let variant: 'successText' | 'warningText' | 'errorText' | 'body3';
+          if (value.isMandatory && (value.result)) {
             variant = 'successText';
+          } else if (!value.isMandatory && (value.result)) {
+            variant = 'warningText';
           } else if (value.result === false) {
             variant = 'errorText';
           } else {

--- a/frontend/src/styles/mui_style.d.ts
+++ b/frontend/src/styles/mui_style.d.ts
@@ -55,12 +55,14 @@ declare module "@mui/material/styles" {
 
   interface TypographyVariants {
     successText?: React.CSSProperties;
+    warningText?: React.CSSProperties;
     errorText?: React.CSSProperties;
     body3?: React.CSSProperties;
   }
 
   interface TypographyVariantsOptions {
     successText?: React.CSSProperties;
+    warningText?: React.CSSProperties;
     errorText?: React.CSSProperties;
     body3?: React.CSSProperties;
   }
@@ -69,6 +71,7 @@ declare module "@mui/material/styles" {
 declare module '@mui/material/Typography' {
   interface TypographyPropsVariantOverrides {
     successText: true;
+    warningText: true;
     errorText: true;
     body3: true;
   }

--- a/frontend/src/styles/theme.tsx
+++ b/frontend/src/styles/theme.tsx
@@ -43,6 +43,13 @@ export const getTheme = (mode: 'light' | 'dark',) => createTheme({
         margin: '12px 0px 0px 0px',
         display: 'block',
       },
+      warningText: {
+        fontSize: '12px',
+        color: '#C1CD39 !important',
+        fontWeight: 600,
+        margin: '12px 0px 0px 0px',
+        display: 'block',
+      },
       errorText: {
         fontSize: '12px',
         color: '#BA1A1A !important',
@@ -227,6 +234,9 @@ export const getTheme = (mode: 'light' | 'dark',) => createTheme({
           fontSize: 'small', 
         },
         styleOverrides: {
+          colorSecondary: {
+            color: '#C1CD39',
+          },
           colorAction: ({ theme }) => ({
             color: theme.palette.onVariant.main,
           }),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -184,6 +184,7 @@ export type GuardrailResult = {
   description: string;
   message: string | null;
   result: boolean | null;
+  resultMandatory: boolean | null;
 };
 
 export type ParameterValidationResult = {


### PR DESCRIPTION
-changed the status indicators in both the tables
-changed the status indicator in the drawer that shows more details, the tile of the guardrail shown in this drawer now allows for 3 different status options
-changed the input fields to only show an error state if the summaryMandatory fails 

#72 