### PR TITLE
feat: Display the error message for failed guardrails

### DIFF
--- a/frontend/src/compositions/InputGroup/Input.tsx
+++ b/frontend/src/compositions/InputGroup/Input.tsx
@@ -51,7 +51,7 @@ const Input = (props: InputProps) => {
           <InputAdornment position="end">
             {error && !isFocused ? (
               <Tooltip title={props.getFieldState(props.field.name, props.formState).error?.message}>
-                <ErrorOutlineOutlinedIcon />
+                <ErrorOutlineOutlinedIcon sx={{margin: '5px'}}/>
               </Tooltip>
             ) : (
               <IconButton

--- a/frontend/src/compositions/MoreDetailsDrawer.tsx
+++ b/frontend/src/compositions/MoreDetailsDrawer.tsx
@@ -103,10 +103,7 @@ export default function MoreDetailsDrawer() {
             <div key={key}>
               <Typography variant={variant}>{key}</Typography>
               <Typography variant='body1'>
-                {value.description}           
-              </Typography>
-              <Typography variant='body1'>
-                {!value.result ? `${value.message}` : null}
+                {value.result === false ? `${value.message}` : value.description}           
               </Typography>
               <Divider className="drawerDivider" />
             </div>

--- a/frontend/src/compositions/MoreDetailsDrawer.tsx
+++ b/frontend/src/compositions/MoreDetailsDrawer.tsx
@@ -103,7 +103,10 @@ export default function MoreDetailsDrawer() {
             <div key={key}>
               <Typography variant={variant}>{key}</Typography>
               <Typography variant='body1'>
-                {value.description}
+                {value.description}           
+              </Typography>
+              <Typography variant='body1'>
+                {!value.result ? `${value.message}` : null}
               </Typography>
               <Divider className="drawerDivider" />
             </div>


### PR DESCRIPTION
When a guardrail fails, the backend returns a message to explain (a bit) why it failed.