### PR TITLE
update run icon and not mandatory but failing status color

### DIFF
--- a/frontend/src/compositions/SideDrawer.tsx
+++ b/frontend/src/compositions/SideDrawer.tsx
@@ -116,7 +116,7 @@ export default function SideDrawerLeft() {
       >
         <Toolbar role="toolbar">
             <Typography variant={'h5'}>
-              Proposal Parameter Checker
+              Proposal Parameter Guardrail Checker
             </Typography>
         </Toolbar>
         
@@ -136,7 +136,7 @@ export default function SideDrawerLeft() {
               <Typography variant={'h6'}>
                 Change Parameter Value
               </Typography>
-              <Button color='primary' variant='text' disableRipple disableFocusRipple onClick={handleRunCheck}>Run</Button>
+              <Button sx={{marginRight: '16px'}} color='primary' variant='outlined' disableRipple disableFocusRipple onClick={handleRunCheck}>Run</Button>
             </SpBtwn>
 
             <ScrollBar>

--- a/frontend/src/styles/theme.tsx
+++ b/frontend/src/styles/theme.tsx
@@ -244,7 +244,7 @@ export const getTheme = (mode: 'light') => createTheme({
         },
         styleOverrides: {
           colorSecondary: {
-            color: '#C1CD39',
+            color: '#CD8939',
           },
           colorAction: ({ theme }) => ({
             color: theme.palette.onVariant.main,
@@ -459,11 +459,6 @@ export const getTheme = (mode: 'light') => createTheme({
           hover: ({ theme }) => ({
               backgroundColor: 'rgba(27, 27, 31, 0.1)',
           }),
-          root: {
-          '&:last-child td': {
-            border: 0
-          },
-          }
         },
       }, 
       MuiTableCell: {


### PR DESCRIPTION
-changed the 'run' button to an outlined variant so it stands out more
-changed the color for when the status icons are indicating that a parameter failed a guardrail check that is not mandatory  